### PR TITLE
Completes #46 (admin can add an organisation)

### DIFF
--- a/test/organisations/admin-adds-org.js
+++ b/test/organisations/admin-adds-org.js
@@ -22,7 +22,8 @@ tape('orgs/add adds a new organisation', t => {
   server.inject(options, reply => {
     t.equal(200, reply.statusCode, 'route exists and replies 200');
     // check organisation has been added to db
-    client.LRANGE('organisations', (err, orgs) => {
+    client.LRANGE('organisations', 0, -1, (error, orgs) => {
+      console.log('ERROR', error);
       t.deepEqual(JSON.parse(orgs[0]), mockData.orgsAddDB, 'new organisation has correct fields');
       t.end();
     });


### PR DESCRIPTION
- Tests for the userflow
- Adds functionality to create a new organisation entry

@JMurphyWeb I think this closes #46. Could you have a pass at the commits and let me know what you think? I've deliberately not ticked some of the boxes in the description section of #46 because- if I remember correctly - we agreed that organisations would need to be created first before the primary users for those organisations could be created, and the components that remain unticked (excluding AWS and auth) are from prior to having that convo. I'll add a comment to reiterate this on the relevant technical issue now, but please correct me if I'm wrong or if you'd prefer to do something in a different way! Keen to hear your thoughts on everything.