### PR TITLE
#305 - displaying admin-navbar and topnav

### DIFF
--- a/server/handlers/create-user-view.js
+++ b/server/handlers/create-user-view.js
@@ -7,7 +7,7 @@ module.exports = (request, reply, source, joiErr) => {
   var permissions = helpers.getPermissions(loggedIn, 'scope', 'admin');
   request.redis.LRANGE('organisations', 0, -1, (redisErr, stringifiedOrgs) => {
     Hoek.assert(!redisErr, 'redis error');
-    var options = Object.assign({}, helpers.orgsDropdown(stringifiedOrgs), helpers.userTypeRadios(), {permissions}, {error});
+    var options = Object.assign({}, helpers.orgsDropdown(stringifiedOrgs), helpers.userTypeRadios(), permissions, {error});
     reply.view('people/add', options).code(error ? 401 : 200);
   });
 };


### PR DESCRIPTION
closes #305 

adminNavbar and topNav were not displaying for add-new-user-view.
'permissions' were not being added to the options correctly --> changing this, fixed the issue.