### PR TITLE
Closes #308 - sets isSecure option (cookies) to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ git clone https://github.com/emfoundation/ce100-app.git
 Ensure you have the required `.env` file, then run:
 
 ```sh
-npm run csv-to-json
+npm i
+npm run generate-tags
 npm start
 ```
-
 
 ### Required Environment Variables
 
@@ -83,6 +83,10 @@ node test/auth/auth.test.js
 #### Adding/Updating Tags (Admin)
 
 Please refer to the [wiki](https://github.com/emfoundation/ce100-app/wiki/Add-Update-Tags) for information on how to do this.
+
+#### HTTP/HTTPS (Admin)
+
+Once the domain's HTTP/TCP protocol has been decided on, it might make sense to change ```isSecure: false``` on [line5 of server/auth.js](https://github.com/emfoundation/ce100-app/blob/master/server/auth.js#L5)
 
 ## Questions?
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "inert": "^4.0.2",
     "iron": "^4.0.3",
     "joi": "^9.0.4",
+    "jsonwebtoken": "^7.1.9",
     "redis": "^2.6.2",
     "redis-connection": "^5.0.0",
     "sendemail": "^2.3.0",

--- a/server/auth.js
+++ b/server/auth.js
@@ -2,7 +2,7 @@ exports.register = (server, options, next) => {
   server.register(require('hapi-auth-jwt2'));
 
   var tokenOptions = {
-    isSecure: process.env.NODE_ENV !== 'development',
+    isSecure: false, // CHANGE ONCE WE KNOW WHETHER THE WEBSITE WILL *DEFINITELY* BE HTTP OR HTTPS
     ttl: 1000 * 60 * 60 * 24 * 30,
     path: '/'
   };


### PR DESCRIPTION
see #308 
You could not log into the app _unless_ you were on https://staging-ce100-emf.herokuapp.com because isSecure was set to ```process.env.NODE_ENV !== 'development'``` (i.e. _true_)

Has been set to _false_ which fixes this issue. Can be changed once the domain of the app has been verified (- instructions have been added to the README.md)