### PR TITLE
fixes naming convention in tags-categories handlebar

### DIFF
--- a/templates/partials/filter-tags-categories.html
+++ b/templates/partials/filter-tags-categories.html
@@ -1,12 +1,12 @@
-<label class="tag__title" for="{{id_cat}}">{{name_cat}}</label>
+<label class="tag__title" for="{{category_id}}">{{category_name}}</label>
 <input  type="checkbox"
         class="tag__input"
-        id="{{id_cat}}">
+        id="{{category_id}}">
 
 <div class="form__subsection">
   {{#each tags}}
-    <a class="text-decoration" href="/{{../pageType}}?tags={{@key}}">
-      <span class="tag__label">{{name_tag}}</span>
+    <a class="text-decoration" href="/{{../pageType}}?tags={{tag_id}}">
+      <span class="tag__label">{{tag_name}}</span>
     </a>
   {{/each}}
 </div>


### PR DESCRIPTION
Closes #411

Updates naming convention of tags-categories.html so that tags are displayed correctly
Has been applied to /orgs endpoint to verify that we get what we want.

#### PLEASE (REVIEW AND) MERGE THIS IN BEFORE #387 and #404! 
#### THANK YOU :musical_note: 