### PR TITLE
fixes toggle cursor width

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -529,6 +529,7 @@ Light-teal:     #66d9e0;
 .form {
     margin-top: 2rem;
     padding: 0 7%;
+    text-align: center;
 }
 .form--login {
     margin-top: 3rem;
@@ -555,6 +556,7 @@ Light-teal:     #66d9e0;
         }
     .form__label, .form__input {
         display: block;
+        text-align: left;
         font-size: 1rem;
     }
 
@@ -691,7 +693,7 @@ Light-teal:     #66d9e0;
 
 .anchor:link {
     text-align: center;
-    display: block;
+    display: inline-block;
     line-height: 2.75;
     color: #89a0ae;
 }


### PR DESCRIPTION
Closes #474

The enable/disable and archive/unarchive link was the width of the page, instead of being just the width of the words. Fixed by changing anchor to inline-block and applies text-center to form div