### PR TITLE
adds /insights/tags filter-browse-view

### DIFF
--- a/server/routes/insights.js
+++ b/server/routes/insights.js
@@ -10,7 +10,7 @@ var maxAllowedTags = require('../models/max-allowed-tags.js');
 var browseInsights = require('../handlers/insights/browse-insights.js');
 var addView = require('../handlers/insights/add-view.js');
 var addSubmit = require('../handlers/insights/add.js');
-var addModel = require('../models/add-insight.js');
+var browseAddTagsView = require('../handlers/shared/browse-add-tags-view.js');
 
 module.exports = [
   {
@@ -54,5 +54,10 @@ module.exports = [
     path: '/insights/add',
     handler: addSubmit,
     config: { validate: addModel }
+  },
+  {
+    method: 'GET',
+    path: '/insights/tags',
+    handler: browseAddTagsView('insights')
   }
 ];


### PR DESCRIPTION
Closes #533

Adds the /insights/tags route as it was missing in the `insights.js` route file