### PR TITLE
updates route for tags on org profile

### DIFF
--- a/templates/views/organisations/details.html
+++ b/templates/views/organisations/details.html
@@ -29,7 +29,7 @@
       <div class="card">
         <h2 class="card__header">Our experience</h2>
         {{#each org.tags}}
-          <a href="/challenges?tags={{tag_id}}"><span class="tag__label">{{tag_name}}</span></a>
+          <a href="/orgs?tags={{tag_id}}"><span class="tag__label">{{tag_name}}</span></a>
         {{/each}}
       </div>
     {{/if}}

--- a/test/organisations/add-tags-to-org.test.js
+++ b/test/organisations/add-tags-to-org.test.js
@@ -14,7 +14,7 @@ function addTagsToOrg (user, orgId, tags) {
 }
 
 function selectedTag (id) {
-  return '<a href="/challenges?tags=' + id + '">';
+  return '<a href="/orgs?tags=' + id + '">';
 }
 
 var getOrgDetails = {


### PR DESCRIPTION
Fixes the bug in #21 

On clicking a tag on an org profile, we were being redirected to `/challenges?tag=` instead of `/orgs?tag=`. This PR fixes this.