### PR TITLE
Cancel button dynamic redirect

### DIFF
--- a/server/handlers/challenges/challenge-view.js
+++ b/server/handlers/challenges/challenge-view.js
@@ -26,7 +26,12 @@ module.exports = function (request, reply) {
       return reply(Boom.forbidden('You are not allowed to view that challenge'));
     }
 
-    options = Object.assign({}, permissions, { challenge: challenge });
+    options = Object.assign(
+      {},
+      permissions,
+      { challenge: challenge },
+      { cancelUrl: helpers.getCancelUrl(request) }
+    );
     // if the logged in user does not belong to this challenges org or is not an
     // admin then they will not be able to see suggested matches
     if (!options.permissions.editable) {

--- a/server/handlers/helpers.js
+++ b/server/handlers/helpers.js
@@ -1,3 +1,6 @@
+'use strict';
+
+var url = require('url');
 var helpers = {};
 
 var INSIGHT_TYPES = [
@@ -133,5 +136,21 @@ helpers.errorOptions = (err) =>
     message: err.data.details[0].message.split('"').join('').split('_').join(' ').split('-').join(' '),
     [err.data.details[0].path]: 'form__input-error'
   };
+
+
+
+/* --------- view logic helpers ----------- */
+
+helpers.getCancelUrl = function (req) {
+  var defaultHomePage = req.auth.credentials.organisation_id
+    ? '/orgs/' + req.auth.credentials.organisation_id // non-admin default
+    : '/orgs'; // admin default
+  var previous = url.parse(req.info.referrer).path;
+  var current = req.path;
+
+  // if the previous path is same as current, redirect to the user's default
+  return current === previous ? defaultHomePage : previous;
+};
+
 
 module.exports = helpers;

--- a/server/handlers/orgs/browse-orgs.js
+++ b/server/handlers/orgs/browse-orgs.js
@@ -14,7 +14,6 @@ module.exports = function (request, reply) {
   request.server.methods.pg.organisations.orgsGetByTag(
     !permissions.permissions.admin, filterTag,
     function (pgErr, data) {
-      console.log(data.filter);
       Hoek.assert(!pgErr, 'error getting challenges by tag');
       options = Object.assign(
         {},

--- a/templates/views/challenges/details.html
+++ b/templates/views/challenges/details.html
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="card card--header">
     <h1 class="title">Challenge</h1>
-    <a class="icon icon--cancel" href="/orgs/{{challenge.org_id}}"></a>
+    <a class="icon icon--cancel" href="{{cancelUrl}}"></a>
   </div>
 
   <div class="card card--challenge">

--- a/test/runner.js
+++ b/test/runner.js
@@ -41,4 +41,6 @@ require('./people/add-user.test.js');
 // tags
 require('./browse/select-tags-browse-view.test.js');
 
+require('./unit/getCancelUrl.js');
+
 require('./server/auth.test.js');

--- a/test/unit/getCancelUrl.js
+++ b/test/unit/getCancelUrl.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var tape = require('tape');
+var getCancelUrl = require('../../server/handlers/helpers.js').getCancelUrl;
+
+// function builds a dummy request with all the keys that `getCancelUrl` uses
+function dummyRequest (referrer, current, org_id) {
+  return {
+    path: current, // '/challenges/2',
+    auth: { credentials: { organisation_id: org_id } }, // null,
+    info: { referrer: 'http://localhost:3000' + referrer } // '/challenges'
+  }
+};
+
+// first array builds dummy request, second string is expected outcome, third is test comment
+var tests = [
+  [['/orgs/1', '/challenges/3'],  '/orgs/1', 'cancel url from viewing an org profile'],
+  [['/orgs', '/challenges/5'], '/orgs', 'cancel url from browse view'],
+  [['/orgs?tags=3', '/challenges/3'], '/orgs?tags=3', 'cancel url from browse with tags'],
+  [['/challenges/3', '/challenges/3', null], '/orgs', 'admin default cancel view is /orgs'],
+  [['/challenges/3', '/challenges/3', 5], '/orgs/5', 'primary default cancel view is their orgs profile']
+];
+
+// cancel url function
+tape('cancel url function gets the correct url', function (t) {
+  tests.forEach(function (test) {
+    var actual = getCancelUrl(dummyRequest.apply(null, test[0]))
+    var expected = test[1];
+
+    t.equal(actual, expected, test[2])
+  });
+  t.end();
+});


### PR DESCRIPTION
 #551 

Add a helper function to redirect user when cancel button pressed.  User should be redirected to the path that they were last on. 

Note this is currently ONLY implemented in the single challenge view, but it can be easily expanded to the app as a whole. Let me know if we want this functionality and I can implement it elsewhere.