### PR TITLE
Removing title-casing from organisation titles

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -410,10 +410,6 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
     font-size: 1rem;
     font-weight: normal;
     color: #ffffff;
-    text-transform: lowercase;
- }
- .title::first-letter {
-   text-transform: uppercase;
  }
 .title--with-logo {
   padding: 0rem;

--- a/templates/partials/organisation.html
+++ b/templates/partials/organisation.html
@@ -1,5 +1,5 @@
 <a class="list__data list__data--primary list__link" href="/orgs/{{id}}">
-  <li class="list__item list__item--medium u-capitalise list__item--desktop">
+  <li class="list__item list__item--medium list__item--desktop">
     {{#if logo_url}}
       <img class="list__logo" src="{{logo_url}}" alt="{{name}} logo">
     {{else}}


### PR DESCRIPTION
We are no longer auto-capitalising the organization title. 

Related to #786,
