### PR TITLE
remove hover highlighting from 3-dots burger menu

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1497,6 +1497,9 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
   }
   .navbar-top__item--burger:hover {
     background-color: #003253;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    box-shadow: none;
   }
   .navbar-top__logo {
     width: 5rem;


### PR DESCRIPTION
Related to original Issue https://github.com/emfoundation/ce100-app/issues/797

Removes box-shadow on burger menu