### PR TITLE
Intercom mobile

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1942,3 +1942,14 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
     width: auto;
   }
 }
+
+/* ---------------------------------------------- */
+/* ---------- INTERCOM MOBILE PLACEMENT ---------- */
+/* ---------------------------------------------- */
+
+
+@media (max-width: 600px) {
+  #intercom-container .intercom-launcher-frame {
+    margin-bottom: 3rem;
+  }
+}


### PR DESCRIPTION
Added specific css for the iframe that controls the itercom on mobile. 

Please Review and Merge after #830 

This is how it looks now on mobile:
<img width="378" alt="screen shot 2017-05-19 at 11 07 05" src="https://cloud.githubusercontent.com/assets/2305591/26243315/5b5167d4-3c83-11e7-9e8b-d1a985263737.png">

