### PR TITLE
updated buttons layout for mobile so that they don't stack on smaller…

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2029,9 +2029,6 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
     bottom: 0;
     left: 0;
     width: 100%;
-  }
-
-  .button-group--modal {
     text-align: center;
   }
 
@@ -2039,7 +2036,9 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
     margin: 1rem;
     float: none;
     width: auto;
+    min-width: 7.8rem;
   }
+
 }
 
 /* ---------------------------------------------- */


### PR DESCRIPTION
… devices.

related to #770

@harrygfox @Jbarget could either of you please have a quick look at this, it's a very minor change for mobile modal buttons. 

### iPhone 6 Plus
<img width="442" alt="screen shot 2017-05-25 at 15 11 53" src="https://cloud.githubusercontent.com/assets/2305591/26453852/145f0532-415d-11e7-9a0d-45937e467c90.png">

### iPhone 5
<img width="371" alt="screen shot 2017-05-25 at 15 12 00" src="https://cloud.githubusercontent.com/assets/2305591/26453884/27c1cf56-415d-11e7-8615-77192250ec01.png">



