### PR TITLE
updated challenge redirect for when a user adds a challenge and selects the close icon.

### DIFF
--- a/server/handlers/helpers.js
+++ b/server/handlers/helpers.js
@@ -146,7 +146,7 @@ helpers.getCancelUrl = function (req) {
   var current = req.path;
 
   // if the previous path is same as current, redirect to the user's default
-  return (current === previous || previous.indexOf('/edit') > -1) ? defaultHomePage : previous;
+  return (current === previous || previous.indexOf('/edit') > -1 || previous.indexOf('/add') > -1) ? defaultHomePage : previous;
 };
 
 helpers.getView = function (url) {


### PR DESCRIPTION
previously they were redirected back to add challenge
now they are redirected to orgs
related #790