### PR TITLE
update pg-challenges to last version (2.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "joi": "^10.4.2",
     "jsonwebtoken": "^7.4.0",
     "pg": "^6.1.5",
-    "pg-challenges": "^2.0.19",
+    "pg-challenges": "^2.1.0",
     "pg-insights": "^0.0.15",
     "pg-people": "^0.0.31",
     "redis": "^2.7.1",


### PR DESCRIPTION
ref: #884 

Update the challenge plugin to the last version which contains the right format for the title column (text)