### PR TITLE
update hapi to version 6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "good-console": "^6.4.0",
     "good-squeeze": "^5.0.2",
     "handlebars": "^4.0.8",
-    "hapi": "^16.1.1",
+    "hapi": "^16.6.0",
     "hapi-auth-jwt2": "^7.2.4",
     "hapi-error": "^1.7.0",
     "hapi-postgres-connection": "^6.1.0",


### PR DESCRIPTION
ref: #901

update Hapi from 6.1 to 6.6.0, this new version fix some security issues discovered in Hapi