### PR TITLE
update challenges plugin to return only active challenges

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "joi": "^10.4.2",
     "jsonwebtoken": "^7.4.0",
     "pg": "^6.1.5",
-    "pg-challenges": "^2.2.1",
+    "pg-challenges": "^2.2.2",
     "pg-insights": "^0.1.4",
     "pg-people": "^0.2.0",
     "redis": "^2.7.1",


### PR DESCRIPTION
ref: #928
Searching for challenges based on their tags only return the active challenges