### PR TITLE
#913 Hover state

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -461,6 +461,10 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
           cursor: pointer;
         }
 
+        .search__go:hover {
+          background-color: #5cc3ca;
+        }
+
   /*|||||||||||||||||||||||||||||||||||||||||||||
     Toggle Bar in browse view
   |||||||||||||||||||||||||||||||||||||||||||*/


### PR DESCRIPTION
#913 Creates hover state of 10% darker color for the 'Go' button on the search bar.