### PR TITLE
Sprint 7 bugs

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2450,7 +2450,13 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
     }
 
     .results--none {
-      padding-left: 3%;
+      padding-left: 8%;
+    }
+
+    @media (min-width: 600px) {
+      .results--none {
+        padding-left: 3%;
+      }
     }
 
     .results__card {
@@ -2515,6 +2521,10 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
   }
 }
 
+.pt3 {
+   padding-top: 1rem;
+ }
+
 .pr4 {
   padding-right: 2rem;
 }
@@ -2553,16 +2563,16 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
   }
 }
 
-.mb3 {
-  margin-bottom: 1rem;
-}
-
 .mr3 {
   margin-right: 1rem;
 }
 
 .mr4 {
   margin-right: 2rem;
+}
+
+.mb3 {
+  margin-bottom: 1rem;
 }
 
 .ml5 {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1578,7 +1578,7 @@ Disabled tag color (50% opacity): rgba(0,50,83, 0.5);*/
     .anchor--grey:link, .anchor--grey:hover, .anchor--grey:visited {
       color: #9cafbb;
     }
-    .anchor--white:link, .anchor--grey:hover, .anchor--grey:visited {
+    .anchor--white:link, .anchor--white:hover, .anchor--white:visited {
       color: #FFFFFF;
       padding-bottom: 2rem;
     }

--- a/templates/views/organisations/details.html
+++ b/templates/views/organisations/details.html
@@ -46,7 +46,7 @@
       </div>
       {{/each}}
       {{else}}
-      <span class="card__data">No challenges shared yet.</span>
+      <span class="card__data pt3 pl2">No challenges shared yet.</span>
       {{/if}}
       <!-- Archived challenges -->
       {{#if permissions.primary}}
@@ -91,9 +91,9 @@
           {{/each}}
         </div>
       {{else}}
-        <div class="card card--desktop">
-          <h2 class="card__header card__header--desktop-large card__header--underline pl3">People</h2>
-          <span class="card__data pl2">No people yet.</span>
+        <div class="card card--desktop pa0">
+          <h2 class="card__header card__header--desktop-large card__header--underline card__header--people">People</h2>
+          <span class="card__data pl2 pb3 tl">No people yet.</span>
         </div>
       {{/if}}
     </div>


### PR DESCRIPTION
#886 final tweaks of bugs so Sprint 7 can be deployed.

- Gives padding to orgs where no people have been added yet so the message displays with spacing.
- Fixes the incorrect color allocation for archived challenges link on desktop to make it grey not white so it can be seen.